### PR TITLE
Select by value

### DIFF
--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -151,7 +151,7 @@ export default class ModalDropdown extends Component {
 
   selectByValue(val) {
     let idx = this.props.options.indexOf(val);
-    select(idx);
+    this.select(idx);
   }
 
   _renderButton() {

--- a/components/ModalDropdown.js
+++ b/components/ModalDropdown.js
@@ -149,6 +149,11 @@ export default class ModalDropdown extends Component {
     });
   }
 
+  selectByValue(val) {
+    let idx = this.props.options.indexOf(val);
+    select(idx);
+  }
+
   _renderButton() {
     return (
       <TouchableOpacity ref={button => this._button = button}


### PR DESCRIPTION
Included a function to set the selection of the dropdown component by value.  If the value does not exist in options, then the same use case of passing in -1 for `select` will occur.